### PR TITLE
Add procfile from stdin support

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 	app.Author = "Sergey \"DarthSim\" Alexandrovich"
 	app.Email = "darthsim@gmail.com"
 	app.Version = version
-	app.ArgsUsage = "[procfile] (Procfile path can be also set with $HIVEMIND_PROCFILE)"
+	app.ArgsUsage = "[procfile] (Use '-' to read from stdin, Procfile path can be also set with $HIVEMIND_PROCFILE)"
 	app.HideHelp = true
 
 	app.Flags = []cli.Flag{

--- a/procfile.go
+++ b/procfile.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"io"
 	"os"
 	"regexp"
 )
@@ -13,11 +14,19 @@ type procfileEntry struct {
 }
 
 func parseProcfile(path string, portBase, portStep int) (entries []procfileEntry) {
+	var f io.Reader
+	switch path {
+	case "-":
+		f = os.Stdin
+	default:
+		file, err := os.Open(path)
+		fatalOnErr(err)
+		defer file.Close()
+
+		f = file
+	}
+
 	re, _ := regexp.Compile(`^([\w-]+):\s+(.+)$`)
-
-	f, err := os.Open(path)
-	fatalOnErr(err)
-
 	port := portBase
 	names := make(map[string]bool)
 


### PR DESCRIPTION
I think this could be pretty handy to have an ability to load `Procfile` from stdin. Because in this case `Procfile` could be easily generated.