### PR TITLE
Remove godotenv (which breaks dotenv) and build a macos arm version

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -17,6 +17,9 @@ gzip -9 -S "-$version-linux-amd64.gz" dist/hivemind
 env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w -X main.version=$version" -a -installsuffix cgo -o dist/hivemind .
 gzip -9 -S "-$version-macos-amd64.gz" dist/hivemind
 
+env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "-s -w -X main.version=$version" -a -installsuffix cgo -o dist/hivemind .
+gzip -9 -S "-$version-macos-arm64.gz" dist/hivemind
+
 env CGO_ENABLED=0 GOOS=freebsd GOARCH=arm go build -ldflags "-s -w -X main.version=$version" -a -installsuffix cgo -o dist/hivemind .
 gzip -9 -S "-$version-freebsd-arm.gz" dist/hivemind
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,6 @@ module github.com/DarthSim/hivemind
 go 1.12
 
 require (
-	github.com/DarthSim/godotenv v1.3.1
-	github.com/joho/godotenv v1.3.0
 	github.com/pkg/term v0.0.0-20160705081919-b1f72af2d630
 	github.com/urfave/cli v1.22.2
 	golang.org/x/sys v0.0.0-20171119032626-0ac51a24ef1c // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DarthSim/godotenv v1.3.1 h1:NMWdswlRx2M9uPY4Ux8p/Q/rDs7A97OG89fECiQ/Tz0=
-github.com/DarthSim/godotenv v1.3.1/go.mod h1:B3ySe1HYTUFFR6+TPyHyxPWjUdh48il0Blebg9p1cCc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
-github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/pkg/term v0.0.0-20160705081919-b1f72af2d630 h1:ZX/9jeXxcLzjhf1Nld8Xx00p3KaxwHkO/wUmTFldenQ=
 github.com/pkg/term v0.0.0-20160705081919-b1f72af2d630/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/main.go
+++ b/main.go
@@ -5,11 +5,9 @@ import (
 	"path/filepath"
 
 	"github.com/urfave/cli"
-
-	_ "github.com/DarthSim/godotenv/autoload"
 )
 
-const version = "1.0.6"
+const version = "1.0.7"
 
 func main() {
 	var (


### PR DESCRIPTION
@DarthSim -

a couple things here, and I didn't mess with tests, so very much assume this is not mergeable as is.... however.

the big thing is removing the `godotenv` module. the reason being, `dotenv` allows you to overload -- so, you can define project envs in `.env`, and say local overrides in `.env.local`, for example. a nice way to prevent committing secrets.

for safety, however, ruby's `dotenv` won't override _existing_ env vars, typically those defined outside the scope of its runtime. 

`godotenv` doesn't understand this functionality, so it's just loading `.env` and nothing else -- and because those vars are defined before ruby starts, ruby's `dotenv` won't override them, and so local env settings are busted. 

tbh, i don't think it's appropriate for `hivemind`  to be including them anyhow. if people want them and they're not already available, it's pretty easy to run a shell/pre-command to define the env within the Procfile... whereas being forced to define them via `godotenv` breaks things. hence the PR. :) 

also, i added a line to build a macos arm64 version, because m1.

hope it helps!