### PR TITLE
Add `--exit-with-highest-exit-code` and `--as-job-runner`

### DIFF
--- a/hivemind.go
+++ b/hivemind.go
@@ -22,6 +22,7 @@ type hivemindConfig struct {
 	NoPrefix           bool
 	PrintTimestamps    bool
 	ExitWithHighest    bool
+	AsJobRunner        bool
 }
 
 type hivemind struct {
@@ -32,6 +33,7 @@ type hivemind struct {
 	done        chan bool
 	interrupted chan os.Signal
 	timeout     time.Duration
+	jobRunner   bool
 }
 
 func newHivemind(conf hivemindConfig) (h *hivemind) {
@@ -44,6 +46,7 @@ func newHivemind(conf hivemindConfig) (h *hivemind) {
 	}
 
 	h.output = &multiOutput{printProcName: !conf.NoPrefix, printTimestamp: conf.PrintTimestamps}
+	h.jobRunner = conf.AsJobRunner
 
 	entries := parseProcfile(conf.Procfile, conf.PortBase, conf.PortStep)
 	h.procs = make([]*process, 0)
@@ -63,17 +66,32 @@ func (h *hivemind) runProcess(proc *process) {
 	h.procWg.Add(1)
 
 	go func() {
-		defer h.procWg.Done()
-		defer func() { h.done <- true }()
+		procSucceed := false
 
-		proc.Run()
+		defer h.procWg.Done()
+		defer func() { h.done <- procSucceed }()
+
+		procSucceed = proc.Run()
 	}()
 }
 
-func (h *hivemind) waitForDoneOrInterrupt() {
+func (h *hivemind) waitForDoneOrInterrupt() bool {
 	select {
-	case <-h.done:
+	case done := <-h.done:
+		return done
 	case <-h.interrupted:
+		return false
+	}
+}
+
+func (h *hivemind) waitForJobsToCompleteOrInterrupt() {
+	jobsCount := len(h.procs)
+
+	for jobsCompleted := 0; jobsCompleted < jobsCount; jobsCompleted++ {
+		succeeded := h.waitForDoneOrInterrupt()
+		if !succeeded {
+			return
+		}
 	}
 }
 
@@ -85,7 +103,11 @@ func (h *hivemind) waitForTimeoutOrInterrupt() {
 }
 
 func (h *hivemind) waitForExit() {
-	h.waitForDoneOrInterrupt()
+	if h.jobRunner {
+		h.waitForJobsToCompleteOrInterrupt()
+	} else {
+		h.waitForDoneOrInterrupt()
+	}
 
 	for _, proc := range h.procs {
 		go proc.Interrupt()

--- a/hivemind.go
+++ b/hivemind.go
@@ -21,6 +21,7 @@ type hivemindConfig struct {
 	Timeout            int
 	NoPrefix           bool
 	PrintTimestamps    bool
+	ExitWithHighest    bool
 }
 
 type hivemind struct {
@@ -97,7 +98,7 @@ func (h *hivemind) waitForExit() {
 	}
 }
 
-func (h *hivemind) Run() {
+func (h *hivemind) Run() int {
 	fmt.Printf("\033]0;%s | hivemind\007", h.title)
 
 	h.done = make(chan bool, len(h.procs))
@@ -112,4 +113,15 @@ func (h *hivemind) Run() {
 	go h.waitForExit()
 
 	h.procWg.Wait()
+
+	exitCode := 0
+
+	for _, proc := range h.procs {
+		code := proc.ProcessState.ExitCode()
+		if code > exitCode {
+			exitCode = code
+		}
+	}
+
+	return exitCode
 }

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ func main() {
 		cli.BoolFlag{Name: "no-prefix", EnvVar: "HIVEMIND_NO_PREFIX", Usage: "process names will not be printed if the flag is specified", Destination: &conf.NoPrefix},
 		cli.BoolFlag{Name: "print-timestamps, T", EnvVar: "HIVEMIND_PRINT_TIMESTAMPS", Usage: "timestamps will be printed if the flag is specified", Destination: &conf.PrintTimestamps},
 		cli.BoolFlag{Name: "exit-with-highest-exit-code, e", EnvVar: "HIVEMIND_EXIT_WITH_HIGHEST_EXIT_CODE", Usage: "exit hivemind with highest exit code from all processes", Destination: &conf.ExitWithHighest},
+		cli.BoolFlag{Name: "as-job-runner", EnvVar: "HIVEMIND_AS_JOB_RUNNER", Usage: "be a job runner instead: Will wait for all to finish with exit code 0, or fail.", Destination: &conf.AsJobRunner},
 	}
 
 	app.Action = func(c *cli.Context) error {

--- a/main.go
+++ b/main.go
@@ -30,14 +30,15 @@ func main() {
 	app.HideHelp = true
 
 	app.Flags = []cli.Flag{
-		cli.StringFlag{Name: "title, w", EnvVar: "HIVEMIND_TITLE", Usage: "Specify a title of the application", Destination: &conf.Title},
-		cli.StringFlag{Name: "processes, l", EnvVar: "HIVEMIND_PROCESSES", Usage: "Specify process names to launch. Divide names with comma", Destination: &conf.ProcNames},
+		cli.StringFlag{Name: "title, w", EnvVar: "HIVEMIND_TITLE", Usage: "specify a title of the application", Destination: &conf.Title},
+		cli.StringFlag{Name: "processes, l", EnvVar: "HIVEMIND_PROCESSES", Usage: "specify process names to launch. Divide names with comma", Destination: &conf.ProcNames},
 		cli.IntFlag{Name: "port, p", EnvVar: "HIVEMIND_PORT,PORT", Usage: "specify a port to use as the base", Value: 5000, Destination: &conf.PortBase},
 		cli.IntFlag{Name: "port-step, P", EnvVar: "HIVEMIND_PORT_STEP", Usage: "specify a step to increase port number", Value: 100, Destination: &conf.PortStep},
 		cli.StringFlag{Name: "root, d", EnvVar: "HIVEMIND_ROOT", Usage: "specify a working directory of application. Default: directory containing the Procfile", Destination: &conf.Root},
 		cli.IntFlag{Name: "timeout, t", EnvVar: "HIVEMIND_TIMEOUT", Usage: "specify the amount of time (in seconds) processes have to shut down gracefully before being brutally killed", Value: 5, Destination: &conf.Timeout},
 		cli.BoolFlag{Name: "no-prefix", EnvVar: "HIVEMIND_NO_PREFIX", Usage: "process names will not be printed if the flag is specified", Destination: &conf.NoPrefix},
 		cli.BoolFlag{Name: "print-timestamps, T", EnvVar: "HIVEMIND_PRINT_TIMESTAMPS", Usage: "timestamps will be printed if the flag is specified", Destination: &conf.PrintTimestamps},
+		cli.BoolFlag{Name: "exit-with-highest-exit-code, e", EnvVar: "HIVEMIND_EXIT_WITH_HIGHEST_EXIT_CODE", Usage: "exit hivemind with highest exit code from all processes", Destination: &conf.ExitWithHighest},
 	}
 
 	app.Action = func(c *cli.Context) error {
@@ -65,7 +66,10 @@ func main() {
 		conf.Root, err = filepath.Abs(conf.Root)
 		fatalOnErr(err)
 
-		newHivemind(conf).Run()
+		exitCode := newHivemind(conf).Run()
+		if exitCode > 0 && conf.ExitWithHighest {
+			return cli.NewExitError("At least one process failed", exitCode)
+		}
 
 		return nil
 	}

--- a/process.go
+++ b/process.go
@@ -56,7 +56,7 @@ func (p *process) Running() bool {
 	return p.Process != nil && p.ProcessState == nil
 }
 
-func (p *process) Run() {
+func (p *process) Run() bool {
 	p.output.PipeOutput(p)
 	defer p.output.ClosePipe(p)
 
@@ -66,8 +66,10 @@ func (p *process) Run() {
 
 	if err := p.Cmd.Run(); err != nil {
 		p.writeErr(err)
+		return false
 	} else {
 		p.writeLine([]byte("\033[1mProcess exited\033[0m"))
+		return true
 	}
 }
 

--- a/test-as-job-runner.sh
+++ b/test-as-job-runner.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+echo
+echo "As process manager"
+dist/hivemind --exit-with-highest-exit-code - <<PROCFILE
+job1: echo "job1 is running"; sleep 0.5; exit 13; echo "Done"
+job2: echo "job2 is running"; sleep 2; echo "Done"
+PROCFILE
+
+echo
+echo "As Job Runner, all completing"
+dist/hivemind --as-job-runner --exit-with-highest-exit-code - <<PROCFILE
+job1: echo "short job1 is running"; sleep 0.5; echo "Done"
+job2: echo "short job2 is running"; sleep 1.0; echo "Done"
+job3: echo "long job3 is running"; sleep 2; echo "Done"
+PROCFILE
+
+echo
+echo "As Job Runner, one exits and fail fast"
+dist/hivemind  --as-job-runner --exit-with-highest-exit-code - <<PROCFILE
+job1: echo "job1 is running"; sleep 0.5; echo "Fail"; exit 13
+job2: echo "job2 is running"; sleep 0.5; echo 1; sleep 0.5; echo 2; sleep 0.5; echo 3; sleep 1; echo "Done"
+PROCFILE


### PR DESCRIPTION
`--exit-with-highest-exit-code` exits `hivemind` with the highest exit code of all processes, which allows for process failures to bubble up to the shell.

This is different from https://github.com/DarthSim/hivemind/pull/30 - this PR does not change current hivemind behaviour. 

Closes https://github.com/DarthSim/hivemind/issues/27

Example:

```shellsession
$ cat <<PROCFILE > example.procfile
job1: echo "job1 is running"; sleep 0.5; echo "Failing"; exit 13
job2: echo "job2 is running"; sleep 1; echo "Will never complete"; exit 11
PROCFILE
$ hivemind --exit-with-highest-exit-code example.procfile
job2 | Running...
job1 | Running...
job2 | job2 is running
job1 | job1 is running
job1 | Failing
job1 | exit status 13
job2 | Interrupting...
job2 | signal: interrupt
At least one process failed
$ echo "Hivemind exited with: $?"
Hivemind exited with: 13
```

`--as-job-runner` changes hivemind from process control to letting jobs run to completion. Example:

```shellsession
$ hivemind --as-job-runner --exit-with-highest-exit-code - <<PROCFILE
job1: echo "job1 is running"; sleep 0.5; echo "Done"
job2: echo "job2 is running"; sleep 1; echo "Done"
PROCFILE
job1 | Running...
job2 | Running...
job2 | job2 is running
job1 | job1 is running
job1 | Done
job1 | Process exited
job2 | Done
job2 | Process exited

$ hivemind  --as-job-runner --exit-with-highest-exit-code - <<PROCFILE
job1: echo "job1 is running"; sleep 0.5; echo "Fail"; exit 13
job2: echo "job2 is running"; sleep 1; echo "Done"
PROCFILE
job2 | Running...
job1 | Running...
job1 | job1 is running
job2 | job2 is running
job1 | Fail
job1 | exit status 13
job2 | Done
job2 | Process exited
At least one process failed
```