### PR TITLE
return first exited process exit code

### DIFF
--- a/hivemind.go
+++ b/hivemind.go
@@ -58,14 +58,14 @@ func newHivemind(conf hivemindConfig) (h *hivemind) {
 	return
 }
 
-func (h *hivemind) runProcess(proc *process) {
+func (h *hivemind) runProcess(proc *process, exitCode chan int) {
 	h.procWg.Add(1)
 
 	go func() {
 		defer h.procWg.Done()
 		defer func() { h.done <- true }()
 
-		proc.Run()
+		exitCode <- proc.Run()
 	}()
 }
 
@@ -97,7 +97,7 @@ func (h *hivemind) waitForExit() {
 	}
 }
 
-func (h *hivemind) Run() {
+func (h *hivemind) Run() int {
 	fmt.Printf("\033]0;%s | hivemind\007", h.title)
 
 	h.done = make(chan bool, len(h.procs))
@@ -105,11 +105,14 @@ func (h *hivemind) Run() {
 	h.interrupted = make(chan os.Signal)
 	signal.Notify(h.interrupted, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
+	exitCodes := make(chan int, len(h.procs))
 	for _, proc := range h.procs {
-		h.runProcess(proc)
+		h.runProcess(proc, exitCodes)
 	}
 
 	go h.waitForExit()
-
 	h.procWg.Wait()
+
+	// note: return first exited process exit code
+	return <-exitCodes
 }

--- a/main.go
+++ b/main.go
@@ -65,7 +65,10 @@ func main() {
 		conf.Root, err = filepath.Abs(conf.Root)
 		fatalOnErr(err)
 
-		newHivemind(conf).Run()
+		exitCode := newHivemind(conf).Run()
+		if exitCode > 0 {
+			os.Exit(exitCode)
+		}
 
 		return nil
 	}

--- a/process.go
+++ b/process.go
@@ -56,7 +56,7 @@ func (p *process) Running() bool {
 	return p.Process != nil && p.ProcessState == nil
 }
 
-func (p *process) Run() {
+func (p *process) Run() int {
 	p.output.PipeOutput(p)
 	defer p.output.ClosePipe(p)
 
@@ -69,6 +69,7 @@ func (p *process) Run() {
 	} else {
 		p.writeLine([]byte("\033[1mProcess exited\033[0m"))
 	}
+	return p.Cmd.ProcessState.ExitCode()
 }
 
 func (p *process) Interrupt() {


### PR DESCRIPTION
This patch enhances existing "fail-fast" behavior. While hivemind already exits when the first process terminates, this change ensures hivemind own exit code mirrors that of the first process to finish.

My main motivation is: I use hivemind in CI workflows to start multiple parallel processes, it is crucial to know if a group of processes finished successfully or with error.
I am aware of this PR https://github.com/DarthSim/hivemind/pull/39, but it has different semantics, suggesting _highest exit code_ instead of _exit code of first finished process_.